### PR TITLE
Rename the main package from eu.cessda.eqb.harvester to eu.cessda.oaiharvester

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ jar-test:
   after_script:
     - echo -n 'Branch coverage ' && grep -oE '<tfoot>.*</tfoot>' target/site/jacoco/index.html | grep -oE '[0-9]{1,3}%' | tail -1
   only:
-    - master
+    - main
     - stable
 
 gesis-maven:
@@ -25,7 +25,7 @@ gesis-maven:
   script:
     - mvn clean deploy -DskipTests
   only:
-    - master
+    - main
     - stable
 
 gesis-docker:
@@ -33,5 +33,5 @@ gesis-docker:
   script:
     - mvn clean -DskipTests package docker:build docker:push -Pdocker-compose
   only:
-    - master
+    - main
     - stable

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,8 @@ pipeline {
     }
 
     environment {
-        product_name = "eqb"
-        module_name = "harvester"
+        product_name = 'eqb'
+        module_name = 'harvester'
         image_tag = "${docker_repo}/${product_name}-${module_name}:${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>eu.cessda.eqb</groupId>
+	<groupId>eu.cessda</groupId>
 	<artifactId>oaiharvester</artifactId>
 	<version>3.2.2-SNAPSHOT</version>
 	<name>CESSDA OAI-PMH Metadata Harvester</name>

--- a/src/main/java/eu/cessda/oaiharvester/DirectoryCreationFailedException.java
+++ b/src/main/java/eu/cessda/oaiharvester/DirectoryCreationFailedException.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L

--- a/src/main/java/eu/cessda/oaiharvester/HTTPException.java
+++ b/src/main/java/eu/cessda/oaiharvester/HTTPException.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L

--- a/src/main/java/eu/cessda/oaiharvester/Harvester.java
+++ b/src/main/java/eu/cessda/oaiharvester/Harvester.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L
@@ -48,7 +48,7 @@ import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 
-import static eu.cessda.eqb.harvester.LoggingConstants.*;
+import static eu.cessda.oaiharvester.LoggingConstants.*;
 import static java.lang.Math.max;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static net.logstash.logback.argument.StructuredArguments.value;

--- a/src/main/java/eu/cessda/oaiharvester/HarvesterConfiguration.java
+++ b/src/main/java/eu/cessda/oaiharvester/HarvesterConfiguration.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L

--- a/src/main/java/eu/cessda/oaiharvester/HttpClient.java
+++ b/src/main/java/eu/cessda/oaiharvester/HttpClient.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L

--- a/src/main/java/eu/cessda/oaiharvester/IOUtilities.java
+++ b/src/main/java/eu/cessda/oaiharvester/IOUtilities.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L

--- a/src/main/java/eu/cessda/oaiharvester/LoggingConstants.java
+++ b/src/main/java/eu/cessda/oaiharvester/LoggingConstants.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L

--- a/src/main/java/eu/cessda/oaiharvester/MetadataCreationFailedException.java
+++ b/src/main/java/eu/cessda/oaiharvester/MetadataCreationFailedException.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L

--- a/src/main/java/eu/cessda/oaiharvester/PipelineMetadata.java
+++ b/src/main/java/eu/cessda/oaiharvester/PipelineMetadata.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L

--- a/src/main/java/eu/cessda/oaiharvester/RecordHeaderException.java
+++ b/src/main/java/eu/cessda/oaiharvester/RecordHeaderException.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L

--- a/src/main/java/eu/cessda/oaiharvester/Repo.java
+++ b/src/main/java/eu/cessda/oaiharvester/Repo.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L

--- a/src/main/java/eu/cessda/oaiharvester/RepositoryClient.java
+++ b/src/main/java/eu/cessda/oaiharvester/RepositoryClient.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L

--- a/src/main/java/org/oclc/oai/harvester2/verb/GetRecord.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/GetRecord.java
@@ -35,7 +35,7 @@ package org.oclc.oai.harvester2.verb;
  * #L%
  */
 
-import eu.cessda.eqb.harvester.HttpClient;
+import eu.cessda.oaiharvester.HttpClient;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 

--- a/src/main/java/org/oclc/oai/harvester2/verb/Identify.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/Identify.java
@@ -35,7 +35,7 @@ package org.oclc.oai.harvester2.verb;
  * #L%
  */
 
-import eu.cessda.eqb.harvester.HttpClient;
+import eu.cessda.oaiharvester.HttpClient;
 import org.xml.sax.SAXException;
 
 import javax.xml.transform.TransformerException;

--- a/src/main/java/org/oclc/oai/harvester2/verb/ListIdentifiers.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/ListIdentifiers.java
@@ -35,7 +35,7 @@ package org.oclc.oai.harvester2.verb;
  * #L%
  */
 
-import eu.cessda.eqb.harvester.HttpClient;
+import eu.cessda.oaiharvester.HttpClient;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;

--- a/src/main/java/org/oclc/oai/harvester2/verb/ListMetadataFormats.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/ListMetadataFormats.java
@@ -35,7 +35,7 @@ package org.oclc.oai.harvester2.verb;
  * #L%
  */
 
-import eu.cessda.eqb.harvester.HttpClient;
+import eu.cessda.oaiharvester.HttpClient;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;

--- a/src/main/java/org/oclc/oai/harvester2/verb/ListRecords.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/ListRecords.java
@@ -35,7 +35,7 @@ package org.oclc.oai.harvester2.verb;
  * #L%
  */
 
-import eu.cessda.eqb.harvester.HttpClient;
+import eu.cessda.oaiharvester.HttpClient;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 

--- a/src/main/java/org/oclc/oai/harvester2/verb/ListSets.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/ListSets.java
@@ -35,7 +35,7 @@ package org.oclc.oai.harvester2.verb;
  * #L%
  */
 
-import eu.cessda.eqb.harvester.HttpClient;
+import eu.cessda.oaiharvester.HttpClient;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;

--- a/src/test/java/eu/cessda/oaiharvester/EQBHarvestingServiceTest.java
+++ b/src/test/java/eu/cessda/oaiharvester/EQBHarvestingServiceTest.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L

--- a/src/test/java/eu/cessda/oaiharvester/IOUtilitiesTests.java
+++ b/src/test/java/eu/cessda/oaiharvester/IOUtilitiesTests.java
@@ -1,4 +1,4 @@
-package eu.cessda.eqb.harvester;
+package eu.cessda.oaiharvester;
 
 /*-
  * #%L

--- a/src/test/java/org/oclc/oai/harvester2/verb/ListIdentifiersTests.java
+++ b/src/test/java/org/oclc/oai/harvester2/verb/ListIdentifiersTests.java
@@ -21,7 +21,7 @@ package org.oclc.oai.harvester2.verb;
  */
 
 
-import eu.cessda.eqb.harvester.HttpClient;
+import eu.cessda.oaiharvester.HttpClient;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 

--- a/src/test/java/org/oclc/oai/harvester2/verb/ListRecordsTests.java
+++ b/src/test/java/org/oclc/oai/harvester2/verb/ListRecordsTests.java
@@ -21,7 +21,7 @@ package org.oclc.oai.harvester2.verb;
  */
 
 
-import eu.cessda.eqb.harvester.HttpClient;
+import eu.cessda.oaiharvester.HttpClient;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.w3c.dom.Element;


### PR DESCRIPTION
The application is no longer part of EQB, so references to EQB should be removed.