### PR TITLE
Add new Sikt and ESS endpoints

### DIFF
--- a/src/main/java/org/oclc/oai/harvester2/verb/ListIdentifiers.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/ListIdentifiers.java
@@ -141,7 +141,7 @@ public final class ListIdentifiers extends HarvesterVerb implements Resumable
 		var records = new ArrayList<RecordHeader>(recordHeaders.getLength());
 		for ( int i = 0; i < recordHeaders.getLength(); i++ )
 		{
-			var identifier = HarvesterVerb.getRecordHeader( recordHeaders.item( i ) );
+			var identifier = getRecordHeader( recordHeaders.item( i ) );
 			records.add(identifier);
 		}
 		return Collections.unmodifiableList(records);

--- a/src/main/java/org/oclc/oai/harvester2/verb/RecordHeader.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/RecordHeader.java
@@ -57,6 +57,7 @@ public record RecordHeader(String identifier, TemporalAccessor datestamp, Set<St
         this.status = status;
     }
 
+    @SuppressWarnings( {"java:S115", "java:S1124"} )
     public enum Status
     {
         deleted

--- a/src/main/resources/application-cdc.yml
+++ b/src/main/resources/application-cdc.yml
@@ -44,7 +44,7 @@ harvester:
     # - url: http://nesstar.soc.cas.cz/oai-pmh/
     #  code: CSDA
     #  name: "Czech Social Science Data Archive (ČSDA)"
-    # metadataPrefixes: oai_ddi 
+    # metadataPrefixes: oai_ddi
     - url: https://easy.dans.knaw.nl/oai/
       code: DANS
       name: DANS-KNAW
@@ -125,6 +125,24 @@ harvester:
         - metadataPrefix: oai_ddi
           ddiVersion: NESSTAR
           validationProfile: https://cmv.cessda.eu/profiles/cdc/ddi-1.2.2/latest/profile.xml
+    - url: https://colectica-ess-published.nsd.no/oai/request
+      code: ESS
+      name: "European Social Survey (ESS)"
+      validationGate: BASIC
+      metadataPrefixes:
+        - metadataPrefix: oai_ddi33
+          ddiVersion: DDI_3_3
+          # Use the DDI 3.2 validation profile for now
+          validationProfile: https://cmv.cessda.eu/profiles/cdc/ddi-3.2/0.1.1/profile.xml
+    - url: https://colectica-forskningsdata-published.nsd.no/oai/request
+      code: Sikt
+      name: "Sikt - Norwegian Agency for Shared Services in Education and Research"
+      validationGate: BASIC
+      metadataPrefixes:
+        - metadataPrefix: oai_ddi33
+          ddiVersion: DDI_3_3
+          # Use the DDI 3.2 validation profile for now
+          validationProfile: https://cmv.cessda.eu/profiles/cdc/ddi-3.2/0.1.1/profile.xml
     # Changed metadata prefix. See #388
     - url: http://147.213.4.44:6003/v0/oai
       code: SASD
@@ -134,7 +152,7 @@ harvester:
         - metadataPrefix: ddi_c
           ddiVersion: DDI_2_5
           validationProfile: https://cmv.cessda.eu/profiles/cdc/ddi-2.5/latest/profile.xml
-    - url: https://snd.gu.se/en/oai-pmh 
+    - url: https://snd.gu.se/en/oai-pmh
       code: SND
       name: "Swedish National Data Service (SND)"
       validationGate: BASIC


### PR DESCRIPTION
This PR also fixes not being able to parse OAI responses that have a namespace prefix (such as `oai:`) defined.

This closes cessda/cessda.cdc.versions#505.