### PR TITLE
Add retry logic for failed HTTP requests

### DIFF
--- a/src/main/java/eu/cessda/oaiharvester/HttpClient.java
+++ b/src/main/java/eu/cessda/oaiharvester/HttpClient.java
@@ -31,6 +31,10 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import static java.io.InputStream.nullInputStream;
 import static java.net.http.HttpClient.Redirect.NORMAL;
@@ -40,6 +44,7 @@ public class HttpClient
 {
     // Logger
     private static final Logger log = LoggerFactory.getLogger( HttpClient.class );
+    private static final int MAX_RETRIES = 3;
 
     private final Methanol client;
 
@@ -54,31 +59,138 @@ public class HttpClient
             .build();
     }
 
+    private static long parseRetryAfterHeader( HttpResponse<?> response )
+    {
+        var retryAfterHeader = response.headers().firstValue( "Retry-After" );
+
+        if (retryAfterHeader.isPresent())
+        {
+            try
+            {
+                // Try parsing as an integer, sleep for the time specified
+                var delaySeconds = Long.parseLong(retryAfterHeader.get());
+                return delaySeconds * 1000L;
+            }
+            catch ( NumberFormatException ignored )
+            {
+                // catch parsing failure if header is a HTTP date
+            }
+
+            try
+            {
+                var httpDate = ZonedDateTime.parse( retryAfterHeader.get(), DateTimeFormatter.RFC_1123_DATE_TIME );
+                var delay = Duration.between( ZonedDateTime.now(), httpDate );
+                if ( delay.isNegative() ) {
+                    // Negative delays are invalid
+                    return -1;
+                }
+                return delay.toMillis();
+            }
+            catch ( DateTimeParseException ignored )
+            {
+                // catch parsing failure if header an invalid format
+            }
+        }
+
+        // header not present or invalid
+        return -1;
+    }
+
     public InputStream getHttpResponse( URI requestURL ) throws IOException
     {
-        int responseCode;
 
         var httpRequest = HttpRequest.newBuilder( requestURL ).GET().build();
+        var bodyHandler = HttpResponse.BodyHandlers.ofInputStream();
 
         try
         {
-            var response = client.send( httpRequest, HttpResponse.BodyHandlers.ofInputStream() );
-
-            responseCode = response.statusCode();
-            log.trace( "responseCode={}", responseCode );
-
-
-            if ( responseCode >= 400 )
-            {
-                throw new HTTPException( requestURL, response.statusCode() );
-            }
-
-            return response.body();
+            return performRequest( httpRequest, bodyHandler ).body();
         }
         catch ( InterruptedException e )
         {
             Thread.currentThread().interrupt();
             return nullInputStream();
         }
+    }
+
+    /**
+     * Perform the HTTP request, retrying in case of connection errors.
+     * @param httpRequest the request to perform.
+     * @param bodyHandler the body handler for the response.
+     * @return the response.
+     * @throws IOException if an IO error occurred when sending the response and the maximum retries have been exceeded.
+     * @throws InterruptedException if the operation is interrupted.
+     */
+    @SuppressWarnings( "java:S3776" ) // Any other way of implementing this logic is more complicated
+    private <T> HttpResponse<T> performRequest( HttpRequest httpRequest, HttpResponse.BodyHandler<T> bodyHandler ) throws InterruptedException, IOException
+    {
+        // Retry counter
+        int retries = 0;
+
+        // Error variables
+        IOException previousException = null;
+        IOException currentException;
+
+        while ( true )
+        {
+            try
+            {
+                var response = client.send( httpRequest, bodyHandler );
+
+                int responseCode = response.statusCode();
+                log.trace( "responseCode={}", responseCode );
+
+                if ( responseCode == 429 || responseCode == 503 )
+                {
+                    // Try to parse the Retry-After header, fall back to default behavior if the header is not present
+                    var delayMilliseconds = parseRetryAfterHeader( response );
+                    if ( delayMilliseconds != -1 )
+                    {
+                        Thread.sleep( delayMilliseconds );
+                        continue;
+                    }
+                }
+
+                if (responseCode >= 400)
+                {
+                    currentException = new HTTPException( httpRequest.uri(), response.statusCode() );
+                    if (responseCode < 500)
+                    {
+                        // 400 response codes are caused by client errors, do not retry
+                        break;
+                    }
+                }
+
+                return response;
+            }
+            catch ( IOException e )
+            {
+                currentException = e;
+            }
+
+            /*
+             * Error handling
+             */
+            if ( previousException != null )
+            {
+                // Suppress the previous exception
+                currentException.addSuppressed( previousException );
+            }
+
+            if ( retries < MAX_RETRIES )
+            {
+                retries++;
+                Thread.sleep( 1000 );
+            }
+            else
+            {
+                break;
+            }
+
+            previousException = currentException;
+        }
+
+        // An error has occurred
+        throw currentException;
     }
 }


### PR DESCRIPTION
The HTTP client will retry 3 times in case of connection or server errors. It will also honour Retry-After headers sent with HTTP 429 and 503 status codes. Client errors, such as all 400 code responses apart from 429, will not be retried.

This closes cessda/cessda.cdc.versions#529.