### PR TITLE
Remove Apache Xalan due to CVE-2022-34169, fix not parsing OAI-PMH metadata formats if the XML uses a namespace prefix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,11 +42,6 @@
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>xalan</groupId>
-			<artifactId>xalan</artifactId>
-			<version>2.7.2</version>
-		</dependency>
 
 		<!-- Json Encoder in Logstash for Logback -->
 		<dependency>

--- a/src/main/java/org/oclc/oai/harvester2/verb/Identify.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/Identify.java
@@ -38,11 +38,9 @@ package org.oclc.oai.harvester2.verb;
 import eu.cessda.oaiharvester.HttpClient;
 import org.xml.sax.SAXException;
 
-import javax.xml.transform.TransformerException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.NoSuchElementException;
 
 /**
  * This class represents an Identify response on either the server or on the client
@@ -67,34 +65,6 @@ public final class Identify extends HarvesterVerb
 		try (var is = httpClient.getHttpResponse( requestURL ))
 		{
 			return new Identify( is );
-		}
-	}
-
-	/**
-	 * Get the oai:protocolVersion value from the Identify response
-	 *
-	 * @return the oai:protocolVersion value
-	 */
-	public String getProtocolVersion()
-	{
-		try
-		{
-			if ( SCHEMA_LOCATION_V2_0.equals( getSchemaLocation() ) )
-			{
-				return getSingleString( "/oai20:OAI-PMH/oai20:Identify/oai20:protocolVersion" );
-			}
-			else if ( SCHEMA_LOCATION_V1_1_IDENTIFY.equals( getSchemaLocation() ) )
-			{
-				return getSingleString( "/oai11_Identify:Identify/oai11_Identify:protocolVersion" );
-			}
-			else
-			{
-				throw new NoSuchElementException( getSchemaLocation() );
-			}
-		}
-		catch ( TransformerException e )
-		{
-			throw new IllegalStateException( e );
 		}
 	}
 

--- a/src/main/java/org/oclc/oai/harvester2/verb/ListMetadataFormats.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/ListMetadataFormats.java
@@ -54,35 +54,33 @@ import java.util.Objects;
  */
 public final class ListMetadataFormats extends HarvesterVerb
 {
-	/**
-	 * Client-side ListMetadataFormats verb constructor
-	 *
-	 * @throws MalformedURLException
-	 *             the baseURL is bad
-	 * @throws SAXException
-	 *             the xml response is bad
-	 * @throws IOException
-	 *             an I/O error occurred
-	 */
-	ListMetadataFormats( InputStream in ) throws IOException, SAXException
-	{
-		super( in );
-	}
+    /**
+     * Client-side ListMetadataFormats verb constructor
+     *
+     * @throws MalformedURLException the baseURL is bad
+     * @throws SAXException          the xml response is bad
+     * @throws IOException           an I/O error occurred
+     */
+    ListMetadataFormats( InputStream in ) throws IOException, SAXException
+    {
+        super( in );
+    }
 
     /**
      * Construct a new {@link ListMetadataFormats} instance from an OAI-PMH repository URL.
+     *
      * @param baseURL the URL of the OAI-PMH repository.
-     * @throws IOException if an IO error occurs.
+     * @throws IOException  if an IO error occurs.
      * @throws SAXException if an error occurs when parsing the XML.
      */
-	public static ListMetadataFormats instance( HttpClient httpClient, URI baseURL ) throws IOException, SAXException
-	{
-		var requestURL = getRequestURL( baseURL, null );
-		try (var in = httpClient.getHttpResponse( requestURL ))
-		{
-			return new ListMetadataFormats( in );
-		}
-	}
+    public static ListMetadataFormats instance( HttpClient httpClient, URI baseURL ) throws IOException, SAXException
+    {
+        var requestURL = getRequestURL( baseURL, null );
+        try ( var in = httpClient.getHttpResponse( requestURL ) )
+        {
+            return new ListMetadataFormats( in );
+        }
+    }
 
     /**
      * Construct a new {@link ListMetadataFormats} instance for a specific record identifier in an OAI-PMH repository
@@ -91,21 +89,40 @@ public final class ListMetadataFormats extends HarvesterVerb
      * @throws IOException if an IO error occurs.
      * @throws SAXException if an error occurs when parsing the XML.
      */
-	public static ListMetadataFormats instance( HttpClient httpClient, URI baseURL, String identifier ) throws IOException, SAXException
-	{
-		Objects.requireNonNull(identifier, "identifier cannot be null");
-		var requestURL = getRequestURL( baseURL, identifier );
-		try (var in = httpClient.getHttpResponse( requestURL ))
-		{
-			return new ListMetadataFormats( in );
-		}
-	}
+    public static ListMetadataFormats instance( HttpClient httpClient, URI baseURL, String identifier ) throws IOException, SAXException
+    {
+        Objects.requireNonNull( identifier, "identifier cannot be null" );
+        var requestURL = getRequestURL( baseURL, identifier );
+        try ( var in = httpClient.getHttpResponse( requestURL ) )
+        {
+            return new ListMetadataFormats( in );
+        }
+    }
+
+    /**
+     * Construct the query portion of the http request
+     *
+     * @return a String containing the query portion of the http request
+     */
+    private static URI getRequestURL( URI baseURL, String identifier )
+    {
+        StringBuilder requestURL = new StringBuilder( baseURL.toString() );
+        requestURL.append( "?verb=ListMetadataFormats" );
+
+        if ( identifier != null )
+        {
+            requestURL.append( "&identifier=" ).append( identifier );
+        }
+
+        return URI.create( requestURL.toString() );
+    }
 
     /**
      * Gets a list of metadata formats.
+     *
      * @throws URISyntaxException if the schema or metadataNamespace elements cannot be parsed as a {@link URI}.
      */
-	public List<MetadataFormat> getMetadataFormats() throws URISyntaxException
+    public List<MetadataFormat> getMetadataFormats() throws URISyntaxException
     {
         var metadataFormats = getDocument().getElementsByTagNameNS( OAI_2_0_NAMESPACE, "metadataFormat" );
 
@@ -122,15 +139,19 @@ public final class ListMetadataFormats extends HarvesterVerb
             for ( int j = 0; j < childNodes.getLength(); j++ )
             {
                 var node = childNodes.item( j );
+                var localName = node.getLocalName();
 
-                switch ( node.getNodeName() )
+                if ( "metadataPrefix".equals( localName ) )
                 {
-                    case "metadataPrefix" -> metadataPrefix = node.getTextContent();
-                    case "schema" -> schema = new URI( node.getTextContent() );
-                    case "metadataNamespace" -> metadataNamespace = new URI( node.getTextContent() );
-                    default -> {
-                        // Unexpected node name - do nothing.
-                    }
+                    metadataPrefix = node.getTextContent().trim();
+                }
+                else if ( "schema".equals( localName ) )
+                {
+                    schema = new URI( node.getTextContent().trim() );
+                }
+                else if ( "metadataNamespace".equals( localName ) )
+                {
+                    metadataNamespace = new URI( node.getTextContent().trim() );
                 }
             }
 
@@ -139,24 +160,6 @@ public final class ListMetadataFormats extends HarvesterVerb
 
         return list;
     }
-
-	/**
-	 * Construct the query portion of the http request
-	 *
-	 * @return a String containing the query portion of the http request
-	 */
-	private static URI getRequestURL( URI baseURL, String identifier )
-	{
-		StringBuilder requestURL = new StringBuilder( baseURL.toString() );
-		requestURL.append( "?verb=ListMetadataFormats" );
-
-		if ( identifier != null )
-		{
-			requestURL.append( "&identifier=" ).append( identifier );
-		}
-
-		return URI.create(requestURL.toString());
-	}
 
     public record MetadataFormat(String metadataPrefix, URI schema, URI metadataNamespace)
     {

--- a/src/main/java/org/oclc/oai/harvester2/verb/ListSets.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/ListSets.java
@@ -54,70 +54,70 @@ import java.util.List;
  */
 public final class ListSets extends HarvesterVerb implements Resumable
 {
-	/**
-	 * Client-side ListSets verb constructor.
-	 *
-	 * @param is the input stream to construct from.
-	 * @throws SAXException if an error occurs parsing the XML.
-	 * @throws IOException          if an I/O error occurred.
-	 */
-	ListSets( InputStream is ) throws IOException, SAXException
-	{
-		super( is );
-	}
+    /**
+     * Client-side ListSets verb constructor.
+     *
+     * @param is the input stream to construct from.
+     * @throws SAXException if an error occurs parsing the XML.
+     * @throws IOException  if an I/O error occurred.
+     */
+    ListSets( InputStream is ) throws IOException, SAXException
+    {
+        super( is );
+    }
 
-	public static ListSets instance( HttpClient httpClient,  URI baseURL) throws IOException, SAXException
-	{
-		var requestURL = getRequestURL( baseURL );
-		try (var is = httpClient.getHttpResponse( requestURL ))
-		{
-			return new ListSets( is );
-		}
-	}
+    public static ListSets instance( HttpClient httpClient, URI baseURL ) throws IOException, SAXException
+    {
+        var requestURL = getRequestURL( baseURL );
+        try ( var is = httpClient.getHttpResponse( requestURL ) )
+        {
+            return new ListSets( is );
+        }
+    }
 
-	public static ListSets instance(HttpClient httpClient, URI baseURL, String resumptionToken) throws IOException, SAXException
-	{
-		var requestURL = getRequestURL( baseURL, resumptionToken );
-		try (var is = httpClient.getHttpResponse( requestURL ))
-		{
-			return new ListSets( is );
-		}
-	}
+    public static ListSets instance( HttpClient httpClient, URI baseURL, String resumptionToken ) throws IOException, SAXException
+    {
+        var requestURL = getRequestURL( baseURL, resumptionToken );
+        try ( var is = httpClient.getHttpResponse( requestURL ) )
+        {
+            return new ListSets( is );
+        }
+    }
 
-	/**
-	 * Returns a list of sets found in the response. The returned list is unmodifiable.
-	 */
-	public List<String> getSets()
-	{
-		var nl = getDocument().getElementsByTagNameNS( OAI_2_0_NAMESPACE, "setSpec" );
-		var sets = new ArrayList<String>(nl.getLength());
-		for ( int i = 0; i < nl.getLength(); i++ )
-		{
-			sets.add( nl.item( i ).getTextContent() );
-		}
-		return Collections.unmodifiableList( sets );
-	}
+    /**
+     * Generate a ListSets URI for the given baseURL
+     *
+     * @param baseURL the base URL of the OAI-PMH repository.
+     */
+    private static URI getRequestURL( URI baseURL )
+    {
+        return URI.create( baseURL + "?verb=ListSets" );
+    }
 
-	/**
-	 * Generate a ListSets URI for the given baseURL
-	 *
-	 * @param baseURL the base URL of the OAI-PMH repository.
-	 */
-	private static URI getRequestURL( URI baseURL )
-	{
-		return URI.create(baseURL + "?verb=ListSets");
-	}
+    /**
+     * Construct the query portion of the http request (resumptionToken version)
+     *
+     * @param baseURL         the base URL of the OAI-PMH repository.
+     * @param resumptionToken the resumption token.
+     */
+    private static URI getRequestURL( URI baseURL, String resumptionToken )
+    {
+        return URI.create( baseURL + "?verb=ListSets"
+            + "&resumptionToken=" + URLEncoder.encode( resumptionToken, StandardCharsets.UTF_8 )
+        );
+    }
 
-	/**
-	 * Construct the query portion of the http request (resumptionToken version)
-	 *
-	 * @param baseURL the base URL of the OAI-PMH repository.
-	 * @param resumptionToken the resumption token.
-	 */
-	private static URI getRequestURL( URI baseURL, String resumptionToken )
-	{
-		return URI.create(baseURL + "?verb=ListSets"
-				+ "&resumptionToken=" + URLEncoder.encode( resumptionToken, StandardCharsets.UTF_8 )
-		);
-	}
+    /**
+     * Returns a list of sets found in the response. The returned list is unmodifiable.
+     */
+    public List<String> getSets()
+    {
+        var nl = getDocument().getElementsByTagNameNS( OAI_2_0_NAMESPACE, "setSpec" );
+        var sets = new ArrayList<String>( nl.getLength() );
+        for ( int i = 0; i < nl.getLength(); i++ )
+        {
+            sets.add( nl.item( i ).getTextContent().trim() );
+        }
+        return Collections.unmodifiableList( sets );
+    }
 }

--- a/src/main/java/org/oclc/oai/harvester2/verb/Resumable.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/Resumable.java
@@ -50,7 +50,7 @@ public interface Resumable
 
         if (resumptionToken.getLength() > 0)
         {
-            var token = resumptionToken.item( 0 ).getTextContent();
+            var token = resumptionToken.item( 0 ).getTextContent().trim();
             if (!token.isEmpty())
             {
                 return Optional.of( token );


### PR DESCRIPTION
In order to be namespace independent, the local name of elements should be used as these don't change when a namespace prefix is used.

See https://github.com/advisories/GHSA-9339-86wc-4qgf for details of CVE-2022-34169.