### PR TITLE
#565: Remove the ability to "unwrap" records, enable streaming records directly to disk

### DIFF
--- a/src/main/java/eu/cessda/oaiharvester/HarvesterConfiguration.java
+++ b/src/main/java/eu/cessda/oaiharvester/HarvesterConfiguration.java
@@ -58,15 +58,7 @@ class HarvesterConfiguration
     /**
      * The output directory of the harvester.
      */
-    private Path dir = Path.of(System.getProperty( "java.io.tmpdir" ));
-    /**
-     * Keep the OAI envelope.
-     */
-    private boolean keepOAIEnvelope = true;
-    /**
-     * Remove the OAI envelope.
-     */
-    private boolean removeOAIEnvelope = false;
+    private Path dir = Path.of( System.getProperty( "java.io.tmpdir" ) ).resolve( "OAI Harvester" );
     /**
      * Incrementally harvest
      */
@@ -79,33 +71,6 @@ class HarvesterConfiguration
      * Timeout for HTTP requests, defaults to 30 seconds if unspecified.
      */
     private Duration timeout = Duration.ofSeconds( 30 );
-
-    /**
-     * Keep the OAI envelope.
-     */
-    public boolean keepOAIEnvelope()
-    {
-        return keepOAIEnvelope;
-    }
-
-    public void setKeepOAIEnvelope( boolean keepOAIEnvelope )
-    {
-        this.keepOAIEnvelope = keepOAIEnvelope;
-    }
-
-    /**
-     * Remove the OAI envelope.
-     */
-    public boolean removeOAIEnvelope()
-    {
-        return removeOAIEnvelope;
-    }
-
-    public void setRemoveOAIEnvelope( boolean removeOAIEnvelope )
-    {
-        this.removeOAIEnvelope = removeOAIEnvelope;
-    }
-
     /**
      * Harvest incrementally.
      */
@@ -190,16 +155,15 @@ class HarvesterConfiguration
         if ( this == o ) return true;
         if ( o == null || getClass() != o.getClass() ) return false;
         HarvesterConfiguration that = (HarvesterConfiguration) o;
-        return keepOAIEnvelope == that.keepOAIEnvelope && removeOAIEnvelope == that.removeOAIEnvelope &&
-                incremental == that.incremental && timeout == that.timeout &&
-                Objects.equals( dir, that.dir ) && Objects.equals( repos, that.repos ) &&
-                Objects.equals( from, that.from );
+        return incremental == that.incremental && timeout == that.timeout &&
+            Objects.equals( dir, that.dir ) && Objects.equals( repos, that.repos ) &&
+            Objects.equals( from, that.from );
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( dir, keepOAIEnvelope, removeOAIEnvelope, incremental, repos, from, timeout );
+        return Objects.hash( dir, incremental, repos, from, timeout );
     }
 
     @Override
@@ -208,8 +172,6 @@ class HarvesterConfiguration
         return "HarvesterConfiguration{" +
                 "repos=" + repos +
                 ", dir=" + dir +
-                ", keepOAIEnvelope=" + keepOAIEnvelope +
-                ", removeOAIEnvelope=" + removeOAIEnvelope +
                 ", incremental=" + incremental +
                 ", from=" + from +
                 ", timeout=" + timeout +

--- a/src/main/java/org/oclc/oai/harvester2/verb/GetRecord.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/GetRecord.java
@@ -63,34 +63,53 @@ public final class GetRecord extends HarvesterVerb
 	}
 
     /**
-     * Query a OAI-PMH repository for a record using the GetRecord verb.
+     * Query an OAI-PMH repository for a record using the GetRecord verb.
      *
-     * @param httpClient the HTTP client to use.
-     * @param baseURL the baseURL of the server to be queried.
-     * @param identifier the record identifier.
+     * @param httpClient     the HTTP client to use.
+     * @param baseURL        the baseURL of the server to be queried.
+     * @param identifier     the record identifier.
      * @param metadataPrefix the metadata prefix of the record to retrieve.
-     * @throws IOException if an IO error occurred.
+     * @throws IOException  if an IO error occurred.
      * @throws SAXException if the XML could not be parsed.
      */
-	public static GetRecord instance( HttpClient httpClient, URI baseURL, String identifier, String metadataPrefix ) throws IOException, SAXException
-	{
-        var requestURL = URI.create( baseURL + "?verb=GetRecord"
+    public static GetRecord instance( HttpClient httpClient, URI baseURL, String identifier, String metadataPrefix ) throws IOException, SAXException
+    {
+        var requestURL = getRequestURL( baseURL, identifier, metadataPrefix );
+
+        try ( var in = httpClient.getHttpResponse( requestURL ) )
+        {
+            return new GetRecord( in );
+        }
+    }
+
+    /**
+     * Get an OAI-PMH GetRecord request as an input stream.
+     *
+     * @param httpClient     the HTTP client to use.
+     * @param baseURL        the baseURL of the server to be queried.
+     * @param identifier     the record identifier.
+     * @param metadataPrefix the metadata prefix of the record to retrieve.
+     * @throws IOException if an IO error occurred.
+     */
+    public static InputStream asStream( HttpClient httpClient, URI baseURL, String identifier, String metadataPrefix ) throws IOException
+    {
+        var requestURL = getRequestURL( baseURL, identifier, metadataPrefix );
+        return httpClient.getHttpResponse( requestURL );
+    }
+
+    private static URI getRequestURL( URI baseURL, String identifier, String metadataPrefix )
+    {
+        return URI.create( baseURL + "?verb=GetRecord"
             + "&identifier=" + identifier
             + "&metadataPrefix=" + metadataPrefix
         );
+    }
 
-		try (var in = httpClient.getHttpResponse( requestURL ))
-		{
-			return new GetRecord( in );
-		}
-	}
-
-	/**
-	 * Get the oai:record header.
-	 *
-	 */
-	public RecordHeader getHeader()
-	{
+    /**
+     * Get the oai:record header.
+     */
+    public RecordHeader getHeader()
+    {
         var recordHeader = getDocument().getElementsByTagNameNS( OAI_2_0_NAMESPACE, "header" );
         var headerNode = recordHeader.item( 0 );
         return getRecordHeader( headerNode );

--- a/src/test/java/eu/cessda/oaiharvester/EQBHarvestingServiceTests.java
+++ b/src/test/java/eu/cessda/oaiharvester/EQBHarvestingServiceTests.java
@@ -61,7 +61,7 @@ class EQBHarvestingServiceTests
         var httpClient = mock( HttpClient.class );
         when( httpClient.getHttpResponse( any(URI.class) ) ).thenReturn( nullInputStream() );
 
-        return new Harvester( httpClient, harvesterConfiguration, new IOUtilities(), new RepositoryClient( httpClient ) );
+        return new Harvester( httpClient, harvesterConfiguration, new RepositoryClient( httpClient ) );
 	}
 
 	@Test
@@ -70,7 +70,7 @@ class EQBHarvestingServiceTests
 		getHarvester( tempDir ).run();
 
         // Read pipeline.json, assert fields are as expected.
-        var pipeline = new ObjectMapper().readValue( new File(tempDir + "/wrapped/TEST/oai_ddi/pipeline.json"), PipelineMetadata.class );
+        var pipeline = new ObjectMapper().readValue( new File( tempDir + "/TEST/oai_ddi/pipeline.json" ), PipelineMetadata.class );
         assertEquals( testRepository.code(), pipeline.code() );
         assertEquals( testRepository.name(), pipeline.name() );
         assertEquals( testRepository.url(), pipeline.url() );

--- a/src/test/java/eu/cessda/oaiharvester/IOUtilitiesTests.java
+++ b/src/test/java/eu/cessda/oaiharvester/IOUtilitiesTests.java
@@ -24,12 +24,7 @@ package eu.cessda.oaiharvester;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.oclc.oai.harvester2.verb.RecordHeader;
-import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.dom.DOMSource;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +32,6 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Random;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,31 +53,6 @@ class IOUtilitiesTests
 
         // Assert that the returned path is equal to the expected path
         assertThat( createdDirectory ).isEqualTo( tempDir.resolve( dirToCreate ) );
-    }
-
-    @Test
-    void shouldWriteSourceToXMLFile(@TempDir Path tempDir) throws ParserConfigurationException, IOException, TransformerException, SAXException
-    {
-        var documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        var uuid = UUID.randomUUID();
-
-        // Create XML document
-        var testDocument = documentBuilder.newDocument();
-        var rootElement = testDocument.createElement( "testNode" );
-        testDocument.appendChild( rootElement );
-        rootElement.appendChild( testDocument.createTextNode( uuid.toString() ) );
-
-        // Write out the XML
-        var tempFile = tempDir.resolve( uuid + ".xml" );
-        new IOUtilities().writeDomSource( new DOMSource(testDocument), tempFile );
-
-        assertThat( tempFile ).exists();
-
-        // Parse the XML
-        var parsedDocument = documentBuilder.parse( tempFile.toFile() );
-
-        // The parsed document should have node equality
-        assertThat(parsedDocument.isEqualNode( testDocument )).isTrue();
     }
 
     @Test

--- a/src/test/java/org/oclc/oai/harvester2/verb/GetRecordTests.java
+++ b/src/test/java/org/oclc/oai/harvester2/verb/GetRecordTests.java
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class GetRecordTests
@@ -53,10 +54,10 @@ class GetRecordTests
               <setSpec>math</setSpec>
             </header>
             <metadata>
-              <oai_dc:dc\s
-                 xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"\s
-                 xmlns:dc="http://purl.org/dc/elements/1.1/"\s
-                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\s
+              <oai_dc:dc
+                 xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                 xmlns:dc="http://purl.org/dc/elements/1.1/"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
                  http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
                 <dc:title>Using Structural Metadata to Localize Experience of Digital Content</dc:title>
@@ -113,12 +114,29 @@ class GetRecordTests
             new RecordHeader(
                 "oai:arXiv.org:cs/0112017",
                 LocalDate.of( 2001, 12, 14 ),
-                Set.of("cs", "math"),
+                Set.of( "cs", "math" ),
                 null
             ),
             header
         );
     }
+
+    @Test
+    void shouldReturnARecordsMetadata() throws IOException, SAXException
+    {
+        var record = new GetRecord(
+            new ByteArrayInputStream( GET_RECORD_RESPONSE.getBytes( StandardCharsets.UTF_8 ) )
+        );
+
+        assertThat( record.getMetadata() )
+            .isPresent()
+            .hasValueSatisfying( element ->
+            {
+                assertThat( element.getNamespaceURI() ).isEqualTo( "http://www.openarchives.org/OAI/2.0/oai_dc/" );
+                assertThat( element.getLocalName() ).isEqualTo( "dc" );
+            } );
+    }
+
 
     @Test
     void shouldHandleADeletedRecord() throws IOException, SAXException


### PR DESCRIPTION
Due to https://github.com/cessda/cessda.cmv.core/issues/80 being resolved, the ability to "unwrap" records is no longer required. Because of this we no longer need to parse the result of `GetRecord` requests. This PR allows the harvester to stream these requests directly to disk, removing the need to parse the response. This improves performance and reduces memory usage.

This means that OAI-PMH errors that are not accompanied by the appropiate HTTP code will be saved as is.

Records will now be saved to `harvester.dir` rather than in the wrapped/unwrapped subdirectories.

See https://github.com/cessda/cessda.cdc.versions/issues/565 for more context.