### PR TITLE
Fix MD formatting in CHANGELOG.md & change MD007 defaults

### DIFF
--- a/.mdl_custom_style.rb
+++ b/.mdl_custom_style.rb
@@ -1,3 +1,4 @@
 all
 rule 'MD013', :tables => false
 rule 'MD024', :allow_different_nesting => true
+rule 'MD007', :indent => 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed not parsing OAI-PMH metadata formats if a namespace prefix was used (i.e. if `oai:request` was used instead
-  of `request`) by only comparing the local name in a namespace aware
-  context ([PR-9](https://github.com/cessda/cessda.metadata.harvester/pull/9))
+- Fixed not parsing OAI-PMH metadata formats if a namespace prefix was used
+  (i.e. if `oai:request` was used instead of `request`) by only comparing the
+  local name in a namespace aware context
+  ([PR-9](https://github.com/cessda/cessda.metadata.harvester/pull/9))
 
 ### Security
 
@@ -162,15 +163,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   information on the harvesting process only. It contains explicit
   information on e.g. the start, end and result of a harversting run.
 - Configurations for
-   - CSDA
-   - DANS
-   - DBK
-   - DNA
-   - EKKE
-   - FSD
-   - NSD
-   - SND
-   - UKDA
+  - CSDA
+  - DANS
+  - DBK
+  - DNA
+  - EKKE
+  - FSD
+  - NSD
+  - SND
+  - UKDA
 
 ### Changed
 


### PR DESCRIPTION
Fix two defects in CHANGELOG.md regarding markdown style: line lenght in line 33, list indentation in line 165.

Add custom style rule for markdownlint regarding list indentation. It now uses indent level of two whitespaces, which is the default for mdl 0.11.0 that is currently used in SQA.