### PR TITLE
Harvest records to a temporary file, throw an IOException if the HttpClient is interrupted

### DIFF
--- a/src/main/java/eu/cessda/oaiharvester/HttpClient.java
+++ b/src/main/java/eu/cessda/oaiharvester/HttpClient.java
@@ -35,7 +35,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
-import static java.io.InputStream.nullInputStream;
 import static java.net.http.HttpClient.Redirect.NORMAL;
 
 @Component
@@ -47,7 +46,7 @@ public class HttpClient
     private final int retryDelay;
 
     @Autowired
-    public HttpClient(HarvesterConfiguration harvesterConfiguration)
+    public HttpClient( HarvesterConfiguration harvesterConfiguration )
     {
         // TK added default timeout for dataverses taking too long to respond / stall
         this.client = Methanol.newBuilder()
@@ -62,7 +61,7 @@ public class HttpClient
     /**
      * Testing constructor, takes a mock HTTP client
      */
-    HttpClient(java.net.http.HttpClient client)
+    HttpClient( java.net.http.HttpClient client )
     {
         this.client = client;
         this.retryDelay = 0;
@@ -72,12 +71,12 @@ public class HttpClient
     {
         var retryAfterHeader = response.headers().firstValue( "Retry-After" );
 
-        if (retryAfterHeader.isPresent())
+        if ( retryAfterHeader.isPresent() )
         {
             try
             {
                 // Try parsing as an integer, sleep for the time specified
-                var delaySeconds = Long.parseLong(retryAfterHeader.get());
+                var delaySeconds = Long.parseLong( retryAfterHeader.get() );
                 return delaySeconds * 1000L;
             }
             catch ( NumberFormatException ignored )
@@ -89,7 +88,8 @@ public class HttpClient
             {
                 var httpDate = ZonedDateTime.parse( retryAfterHeader.get(), DateTimeFormatter.RFC_1123_DATE_TIME );
                 var delay = Duration.between( ZonedDateTime.now(), httpDate );
-                if ( delay.isNegative() ) {
+                if ( delay.isNegative() )
+                {
                     // Negative delays are invalid
                     return -1;
                 }
@@ -118,16 +118,17 @@ public class HttpClient
         catch ( InterruptedException e )
         {
             Thread.currentThread().interrupt();
-            return nullInputStream();
+            throw new IOException( e );
         }
     }
 
     /**
      * Perform the HTTP request, retrying in case of connection errors.
+     *
      * @param httpRequest the request to perform.
      * @param bodyHandler the body handler for the response.
      * @return the response.
-     * @throws IOException if an IO error occurred when sending the response and the maximum retries have been exceeded.
+     * @throws IOException          if an IO error occurred when sending the response and the maximum retries have been exceeded.
      * @throws InterruptedException if the operation is interrupted.
      */
     @SuppressWarnings( { "java:S3776", "java:S135" } ) // Any other way of implementing this logic is more complicated

--- a/src/main/java/org/oclc/oai/harvester2/verb/GetRecord.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/GetRecord.java
@@ -37,6 +37,7 @@ package org.oclc.oai.harvester2.verb;
 
 import eu.cessda.oaiharvester.HttpClient;
 import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
@@ -57,7 +58,7 @@ public final class GetRecord extends HarvesterVerb
 	 * @throws IOException if an IO error occurs when reading the input stream.
 	 * @throws SAXException if an error occurs when parsing the XML.
 	 */
-	GetRecord( InputStream in ) throws IOException, SAXException
+	GetRecord( InputSource in ) throws IOException, SAXException
 	{
 		super(in);
 	}
@@ -76,9 +77,12 @@ public final class GetRecord extends HarvesterVerb
     {
         var requestURL = getRequestURL( baseURL, identifier, metadataPrefix );
 
-        try ( var in = httpClient.getHttpResponse( requestURL ) )
+        try ( var httpResponse = httpClient.getHttpResponse( requestURL ) )
         {
-            return new GetRecord( in );
+            var inputSource = new InputSource();
+            inputSource.setSystemId( requestURL.toASCIIString() );
+            inputSource.setByteStream( httpResponse );
+            return new GetRecord( inputSource );
         }
     }
 
@@ -131,9 +135,10 @@ public final class GetRecord extends HarvesterVerb
 			for ( int j = 0; j < metadataNodes.getLength(); j++ )
 			{
 			    // Select the first element within the metadata element
-				if ( metadataNodes.item( j ) instanceof Element )
+                var node = metadataNodes.item( j );
+                if ( node instanceof Element element )
                 {
-					return Optional.of( (Element) metadataNodes.item( j ) );
+					return Optional.of( element );
 				}
             }
         }

--- a/src/main/java/org/oclc/oai/harvester2/verb/Identify.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/Identify.java
@@ -36,10 +36,10 @@ package org.oclc.oai.harvester2.verb;
  */
 
 import eu.cessda.oaiharvester.HttpClient;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 
 /**
@@ -54,7 +54,7 @@ public final class Identify extends HarvesterVerb
 	 *
 	 * @throws IOException           an I/O error occurred
 	 */
-	Identify( InputStream is ) throws IOException, SAXException
+	Identify( InputSource is ) throws IOException, SAXException
 	{
 		super( is );
 	}
@@ -62,9 +62,12 @@ public final class Identify extends HarvesterVerb
 	public static Identify instance( HttpClient httpClient, URI baseURL) throws IOException, SAXException
 	{
 		var requestURL = URI.create(baseURL + "?verb=Identify");
-		try (var is = httpClient.getHttpResponse( requestURL ))
+		try (var httpResponse = httpClient.getHttpResponse( requestURL ))
 		{
-			return new Identify( is );
+            var inputSource = new InputSource();
+            inputSource.setSystemId( requestURL.toASCIIString() );
+            inputSource.setByteStream( httpResponse );
+			return new Identify( inputSource );
 		}
 	}
 

--- a/src/main/java/org/oclc/oai/harvester2/verb/ListIdentifiers.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/ListIdentifiers.java
@@ -36,10 +36,10 @@ package org.oclc.oai.harvester2.verb;
  */
 
 import eu.cessda.oaiharvester.HttpClient;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -62,7 +62,7 @@ public final class ListIdentifiers extends HarvesterVerb implements Resumable
 	 * @throws SAXException the xml response is bad
 	 * @throws IOException  an I/O error occurred
 	 */
-	ListIdentifiers( InputStream is ) throws IOException, SAXException
+	ListIdentifiers( InputSource is ) throws IOException, SAXException
 	{
 		super( is );
 	}
@@ -78,9 +78,12 @@ public final class ListIdentifiers extends HarvesterVerb implements Resumable
 	{
         Objects.requireNonNull( resumptionToken, "resumptionToken cannot be null" );
 		var requestURL = getRequestURL( baseURL, resumptionToken );
-		try (var is = httpClient.getHttpResponse( requestURL ))
+		try (var httpResponse = httpClient.getHttpResponse( requestURL ))
 		{
-			return new ListIdentifiers( is );
+            var inputSource = new InputSource();
+            inputSource.setSystemId( requestURL.toASCIIString() );
+            inputSource.setByteStream( httpResponse );
+			return new ListIdentifiers( inputSource );
 		}
 	}
 
@@ -98,9 +101,12 @@ public final class ListIdentifiers extends HarvesterVerb implements Resumable
 			throws IOException, SAXException
 	{
 		var requestURL = getRequestURL( baseURL, from, until, set, metadataPrefix );
-		try (var is = httpClient.getHttpResponse( requestURL ))
+		try (var httpResponse = httpClient.getHttpResponse( requestURL ))
 		{
-			return new ListIdentifiers( is );
+            var inputSource = new InputSource();
+            inputSource.setSystemId( requestURL.toASCIIString() );
+            inputSource.setByteStream( httpResponse );
+			return new ListIdentifiers( inputSource );
 		}
 	}
 

--- a/src/main/java/org/oclc/oai/harvester2/verb/ListMetadataFormats.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/ListMetadataFormats.java
@@ -36,10 +36,10 @@ package org.oclc.oai.harvester2.verb;
  */
 
 import eu.cessda.oaiharvester.HttpClient;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -61,7 +61,7 @@ public final class ListMetadataFormats extends HarvesterVerb
      * @throws SAXException          the xml response is bad
      * @throws IOException           an I/O error occurred
      */
-    ListMetadataFormats( InputStream in ) throws IOException, SAXException
+    ListMetadataFormats( InputSource in ) throws IOException, SAXException
     {
         super( in );
     }
@@ -76,9 +76,12 @@ public final class ListMetadataFormats extends HarvesterVerb
     public static ListMetadataFormats instance( HttpClient httpClient, URI baseURL ) throws IOException, SAXException
     {
         var requestURL = getRequestURL( baseURL, null );
-        try ( var in = httpClient.getHttpResponse( requestURL ) )
+        try ( var httpResponse = httpClient.getHttpResponse( requestURL ) )
         {
-            return new ListMetadataFormats( in );
+            var inputSource = new InputSource();
+            inputSource.setSystemId( requestURL.toASCIIString() );
+            inputSource.setByteStream( httpResponse );
+            return new ListMetadataFormats( inputSource );
         }
     }
 
@@ -93,9 +96,12 @@ public final class ListMetadataFormats extends HarvesterVerb
     {
         Objects.requireNonNull( identifier, "identifier cannot be null" );
         var requestURL = getRequestURL( baseURL, identifier );
-        try ( var in = httpClient.getHttpResponse( requestURL ) )
+        try ( var httpResponse = httpClient.getHttpResponse( requestURL ) )
         {
-            return new ListMetadataFormats( in );
+            var inputSource = new InputSource();
+            inputSource.setSystemId( requestURL.toASCIIString() );
+            inputSource.setByteStream( httpResponse );
+            return new ListMetadataFormats( inputSource );
         }
     }
 

--- a/src/main/java/org/oclc/oai/harvester2/verb/ListRecords.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/ListRecords.java
@@ -37,11 +37,10 @@ package org.oclc.oai.harvester2.verb;
 
 import eu.cessda.oaiharvester.HttpClient;
 import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -57,14 +56,12 @@ public final class ListRecords extends HarvesterVerb implements Resumable
 	/**
 	 * Client-side ListRecords verb constructor
 	 *
-	 * @throws MalformedURLException
-	 *             the baseURL is bad
 	 * @throws SAXException
 	 *             the xml response is bad
 	 * @throws IOException
 	 *             an I/O error occurred
 	 */
-	ListRecords( InputStream is ) throws IOException, SAXException
+	ListRecords( InputSource is ) throws IOException, SAXException
 	{
 		super( is );
 	}
@@ -72,9 +69,12 @@ public final class ListRecords extends HarvesterVerb implements Resumable
 	public static ListRecords instance( HttpClient httpClient, URI baseURL, String resumptionToken ) throws IOException, SAXException
 	{
 		var requestURL = getRequestURL( baseURL, resumptionToken );
-		try (var is = httpClient.getHttpResponse( requestURL ))
+		try (var httpResponse = httpClient.getHttpResponse( requestURL ))
 		{
-			return new ListRecords( is );
+            var inputSource = new InputSource();
+            inputSource.setSystemId( requestURL.toASCIIString() );
+            inputSource.setByteStream( httpResponse );
+			return new ListRecords( inputSource );
 		}
 	}
 
@@ -82,9 +82,12 @@ public final class ListRecords extends HarvesterVerb implements Resumable
 			throws IOException, SAXException
 	{
 		var requestURL = getRequestURL( baseURL, from, until, set, metadataPrefix );
-		try (var is = httpClient.getHttpResponse( requestURL ))
+		try (var httpResponse = httpClient.getHttpResponse( requestURL ))
 		{
-			return new ListRecords( is );
+            var inputSource = new InputSource();
+            inputSource.setSystemId( requestURL.toASCIIString() );
+            inputSource.setByteStream( httpResponse );
+			return new ListRecords( inputSource );
 		}
 	}
 
@@ -96,7 +99,7 @@ public final class ListRecords extends HarvesterVerb implements Resumable
 	/**
 	 * Construct the query portion of the http request
 	 *
-	 * @return a String containing the query portion of the http request
+	 * @return a {@link String} containing the query portion of the http request
 	 */
 	private static URI getRequestURL( URI baseURL, LocalDate from, LocalDate until, String set, String metadataPrefix )
 	{
@@ -120,10 +123,6 @@ public final class ListRecords extends HarvesterVerb implements Resumable
 
 	/**
 	 * Construct the query portion of the http request (resumptionToken version)
-	 *
-	 * @param baseURL
-	 * @param resumptionToken
-	 * @return
 	 */
 	private static URI getRequestURL( URI baseURL, String resumptionToken )
 	{

--- a/src/main/java/org/oclc/oai/harvester2/verb/ListSets.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/ListSets.java
@@ -36,10 +36,10 @@ package org.oclc.oai.harvester2.verb;
  */
 
 import eu.cessda.oaiharvester.HttpClient;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -61,7 +61,7 @@ public final class ListSets extends HarvesterVerb implements Resumable
      * @throws SAXException if an error occurs parsing the XML.
      * @throws IOException  if an I/O error occurred.
      */
-    ListSets( InputStream is ) throws IOException, SAXException
+    ListSets( InputSource is ) throws IOException, SAXException
     {
         super( is );
     }
@@ -69,18 +69,24 @@ public final class ListSets extends HarvesterVerb implements Resumable
     public static ListSets instance( HttpClient httpClient, URI baseURL ) throws IOException, SAXException
     {
         var requestURL = getRequestURL( baseURL );
-        try ( var is = httpClient.getHttpResponse( requestURL ) )
+        try ( var httpResponse = httpClient.getHttpResponse( requestURL ) )
         {
-            return new ListSets( is );
+            var inputSource = new InputSource();
+            inputSource.setSystemId( requestURL.toASCIIString() );
+            inputSource.setByteStream( httpResponse );
+            return new ListSets( inputSource );
         }
     }
 
     public static ListSets instance( HttpClient httpClient, URI baseURL, String resumptionToken ) throws IOException, SAXException
     {
         var requestURL = getRequestURL( baseURL, resumptionToken );
-        try ( var is = httpClient.getHttpResponse( requestURL ) )
+        try ( var httpResponse = httpClient.getHttpResponse( requestURL ) )
         {
-            return new ListSets( is );
+            var inputSource = new InputSource();
+            inputSource.setSystemId( requestURL.toASCIIString() );
+            inputSource.setByteStream( httpResponse );
+            return new ListSets( inputSource );
         }
     }
 

--- a/src/test/java/eu/cessda/oaiharvester/HttpClientTests.java
+++ b/src/test/java/eu/cessda/oaiharvester/HttpClientTests.java
@@ -197,12 +197,7 @@ class HttpClientTests
         var httpClient = new eu.cessda.oaiharvester.HttpClient( clientMock );
 
         // The client should return a successful result
-        var timeBefore = Instant.now();
         assertDoesNotThrow( () -> httpClient.getHttpResponse( URI.create( "http://localhost:8080/" ) ) );
-        var timeAfter = Instant.now();
-
-        // Assert that the appropriate amount of time passed
-        assertThat( Duration.between( timeBefore, timeAfter )).isCloseTo( delay, Duration.ofMillis( 500 ) );
     }
 
     @Test

--- a/src/test/java/eu/cessda/oaiharvester/HttpClientTests.java
+++ b/src/test/java/eu/cessda/oaiharvester/HttpClientTests.java
@@ -184,8 +184,8 @@ class HttpClientTests
     void shouldParseRetryAfterHeaderWithA503StatusCode() throws IOException, InterruptedException
     {
         // Setup variables
-        var delayInSeconds = 2;
-        var expectedTimeAfter = ZonedDateTime.now().plusSeconds( delayInSeconds );
+        var delay = Duration.ofSeconds( 2 );
+        var expectedTimeAfter = ZonedDateTime.now().plus( delay );
 
         var responseHeaders = Map.of( "Retry-After", List.of(DateTimeFormatter.RFC_1123_DATE_TIME.format( expectedTimeAfter )));
 
@@ -197,11 +197,12 @@ class HttpClientTests
         var httpClient = new eu.cessda.oaiharvester.HttpClient( clientMock );
 
         // The client should return a successful result
+        var timeBefore = Instant.now();
         assertDoesNotThrow( () -> httpClient.getHttpResponse( URI.create( "http://localhost:8080/" ) ) );
-        var timeAfter = ZonedDateTime.now();
+        var timeAfter = Instant.now();
 
         // Assert that the appropriate amount of time passed
-        assertThat( Duration.between( expectedTimeAfter, timeAfter )).isCloseTo( Duration.ZERO, Duration.ofSeconds( 500 ) );
+        assertThat( Duration.between( timeBefore, timeAfter )).isCloseTo( delay, Duration.ofMillis( 500 ) );
     }
 
     @Test
@@ -273,8 +274,8 @@ class HttpClientTests
 
         var httpClient = new eu.cessda.oaiharvester.HttpClient( clientMock );
 
-        // The client should return a successful result, and the thread should be interrupted
-        assertDoesNotThrow( () -> httpClient.getHttpResponse( URI.create( "http://localhost:8080/" ) ) );
+        // The client should throw an IOException, and the thread should be interrupted
+        assertThrows( IOException.class, () -> httpClient.getHttpResponse( URI.create( "http://localhost:8080/" ) ) );
         assertTrue( Thread.interrupted() );
     }
 }

--- a/src/test/java/org/oclc/oai/harvester2/verb/GetRecordTests.java
+++ b/src/test/java/org/oclc/oai/harvester2/verb/GetRecordTests.java
@@ -22,6 +22,7 @@ package org.oclc.oai.harvester2.verb;
 
 
 import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
@@ -105,7 +106,7 @@ class GetRecordTests
     void shouldReturnARecordHeader() throws IOException, SAXException
     {
         var record = new GetRecord(
-            new ByteArrayInputStream( GET_RECORD_RESPONSE.getBytes( StandardCharsets.UTF_8 ) )
+            new InputSource( new ByteArrayInputStream( GET_RECORD_RESPONSE.getBytes( StandardCharsets.UTF_8 ) ) )
         );
 
         var header = record.getHeader();
@@ -125,7 +126,7 @@ class GetRecordTests
     void shouldReturnARecordsMetadata() throws IOException, SAXException
     {
         var record = new GetRecord(
-            new ByteArrayInputStream( GET_RECORD_RESPONSE.getBytes( StandardCharsets.UTF_8 ) )
+            new InputSource( new ByteArrayInputStream( GET_RECORD_RESPONSE.getBytes( StandardCharsets.UTF_8 ) ) )
         );
 
         assertThat( record.getMetadata() )
@@ -142,7 +143,7 @@ class GetRecordTests
     void shouldHandleADeletedRecord() throws IOException, SAXException
     {
         var deletedRecord = new GetRecord(
-            new ByteArrayInputStream( DELETED_RECORD.getBytes( StandardCharsets.UTF_8 ) )
+            new InputSource( new ByteArrayInputStream( DELETED_RECORD.getBytes( StandardCharsets.UTF_8 ) ) )
         );
 
         var header = deletedRecord.getHeader();

--- a/src/test/java/org/oclc/oai/harvester2/verb/ListIdentifiersTests.java
+++ b/src/test/java/org/oclc/oai/harvester2/verb/ListIdentifiersTests.java
@@ -23,6 +23,7 @@ package org.oclc.oai.harvester2.verb;
 
 import eu.cessda.oaiharvester.HttpClient;
 import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
@@ -59,8 +60,8 @@ class ListIdentifiersTests
     void shouldReturnRecordHeaders() throws IOException, SAXException
     {
         // Given
-        var identifiers = new ListIdentifiers( new ByteArrayInputStream(
-                GET_LIST_IDENTIFIERS_XML_RESUMPTION_EMPTY.getBytes( UTF_8 )
+        var identifiers = new ListIdentifiers( new InputSource(
+            new ByteArrayInputStream( GET_LIST_IDENTIFIERS_XML_RESUMPTION_EMPTY.getBytes( UTF_8 ) )
         ) );
 
         var identifiersIDs = identifiers.getIdentifiers();
@@ -75,8 +76,8 @@ class ListIdentifiersTests
     void shouldReturnResumptionToken() throws IOException, SAXException
     {
         // Given
-        var identifiers = new ListIdentifiers( new ByteArrayInputStream(
-                GET_LIST_IDENTIFIERS_XML_WITH_RESUMPTION.getBytes( UTF_8 )
+        var identifiers = new ListIdentifiers( new InputSource(
+            new ByteArrayInputStream( GET_LIST_IDENTIFIERS_XML_WITH_RESUMPTION.getBytes( UTF_8 ) )
         ));
 
         assertEquals("3/6/7/ddi/null/2017-01-01/null", identifiers.getResumptionToken().orElseThrow() );
@@ -86,8 +87,8 @@ class ListIdentifiersTests
     void shouldReturnEmptyOptionalForAnEmptyResumptionToken() throws IOException, SAXException
     {
         // Given
-        var identifiers = new ListIdentifiers(new ByteArrayInputStream(
-                GET_LIST_IDENTIFIERS_XML_RESUMPTION_EMPTY.getBytes( UTF_8 )
+        var identifiers = new ListIdentifiers( new InputSource(
+            new ByteArrayInputStream( GET_LIST_IDENTIFIERS_XML_RESUMPTION_EMPTY.getBytes( UTF_8 ) )
         ));
 
         assertTrue( identifiers.getResumptionToken().isEmpty() );
@@ -97,8 +98,8 @@ class ListIdentifiersTests
     void shouldReturnDocumentWhenResumingWithToken() throws IOException, SAXException
     {
         // Given
-        var identifiers = new ListIdentifiers(new ByteArrayInputStream(
-                GET_LIST_IDENTIFIERS_XML_WITH_RESUMPTION_LAST_LIST.getBytes( UTF_8 )
+        var identifiers = new ListIdentifiers( new InputSource(
+            new ByteArrayInputStream( GET_LIST_IDENTIFIERS_XML_WITH_RESUMPTION_LAST_LIST.getBytes( UTF_8 ) )
         ));
 
         // Then
@@ -113,8 +114,8 @@ class ListIdentifiersTests
     void shouldReturnNoRecordsOnError() throws IOException, SAXException
     {
         // Given
-        var identifiers = new ListIdentifiers( new ByteArrayInputStream(
-                GET_LIST_IDENTIFIERS_XML_WITH_CANNOT_DISSEMINATE_FORMAT_ERROR.getBytes( UTF_8 )
+        var identifiers = new ListIdentifiers(  new InputSource(
+            new ByteArrayInputStream( GET_LIST_IDENTIFIERS_XML_WITH_CANNOT_DISSEMINATE_FORMAT_ERROR.getBytes( UTF_8 ) )
         ));
 
         // Then
@@ -157,7 +158,7 @@ class ListIdentifiersTests
     {
         // When
         var listIdentifiers = new ListIdentifiers(
-            new ByteArrayInputStream( NSD_DATE_FORMAT_RESPONSE.getBytes( UTF_8 ) )
+            new InputSource( new ByteArrayInputStream( NSD_DATE_FORMAT_RESPONSE.getBytes( UTF_8 ) ) )
         );
 
         // Then

--- a/src/test/java/org/oclc/oai/harvester2/verb/ListMetadataFormatsTests.java
+++ b/src/test/java/org/oclc/oai/harvester2/verb/ListMetadataFormatsTests.java
@@ -22,6 +22,7 @@ package org.oclc.oai.harvester2.verb;
 
 
 import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
@@ -61,8 +62,8 @@ class ListMetadataFormatsTests
     void shouldReturnAListOfMetadataFormats() throws IOException, SAXException, URISyntaxException
     {
         // Given
-        var metadataFormats = new ListMetadataFormats( new ByteArrayInputStream(
-            LIST_METADATA_FORMATS_RESPONSE.getBytes( StandardCharsets.UTF_8 )
+        var metadataFormats = new ListMetadataFormats( new InputSource(
+            new ByteArrayInputStream( LIST_METADATA_FORMATS_RESPONSE.getBytes( StandardCharsets.UTF_8 ) )
         ));
 
         // Then

--- a/src/test/java/org/oclc/oai/harvester2/verb/ListRecordsTests.java
+++ b/src/test/java/org/oclc/oai/harvester2/verb/ListRecordsTests.java
@@ -25,6 +25,7 @@ import eu.cessda.oaiharvester.HttpClient;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
@@ -100,7 +101,7 @@ class ListRecordsTests
     {
         // When
         var recordList = new ListRecords(
-            new ByteArrayInputStream( LIST_RECORDS_RESPONSE.getBytes( StandardCharsets.UTF_8 ) )
+            new InputSource( new ByteArrayInputStream( LIST_RECORDS_RESPONSE.getBytes( StandardCharsets.UTF_8 ) ) )
         );
 
         // Then

--- a/src/test/java/org/oclc/oai/harvester2/verb/ListSetsTests.java
+++ b/src/test/java/org/oclc/oai/harvester2/verb/ListSetsTests.java
@@ -22,6 +22,7 @@ package org.oclc.oai.harvester2.verb;
 
 
 import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
@@ -92,7 +93,7 @@ class ListSetsTests
         );
 
         // Then
-        var listSets = new ListSets( inputStream );
+        var listSets = new ListSets( new InputSource( inputStream ) );
 
         var sets = listSets.getSets();
 
@@ -110,7 +111,7 @@ class ListSetsTests
         ) ;
 
         // Then
-        var listSets = new ListSets( inputStream );
+        var listSets = new ListSets(  new InputSource( inputStream ) );
 
         var sets = listSets.getSets();
 


### PR DESCRIPTION
These changes are to ensure on a best effort basis that harvested files are complete. By harvesting to a temporary file, the destination file is only replaced when the download completes. By throwing an IOException on interruption, appropiate clean-up code is run and fully downloaded files are not overwritten.