### PR TITLE
#655: Fix SND only harvesting 100 records

### DIFF
--- a/src/main/java/eu/cessda/oaiharvester/RecordHeaderException.java
+++ b/src/main/java/eu/cessda/oaiharvester/RecordHeaderException.java
@@ -21,7 +21,10 @@ package eu.cessda.oaiharvester;
  */
 
 
+import org.oclc.oai.harvester2.verb.RecordHeader;
+
 import java.io.Serial;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -34,18 +37,21 @@ public class RecordHeaderException extends Exception
 
     private final Repo repo;
     private final String set;
+    private final List<RecordHeader> headers;
 
     /**
      * Construct a new instance of a {@link RecordHeaderException}.
      * @param repo the repository that failed.
      * @param set the set that was being harvested, set to {@code null} if no sets were being harvested.
+     * @param headers the list of headers discovered so far.
      * @param cause the cause of this exception.
      */
-    RecordHeaderException( Repo repo, String set, Throwable cause )
+    RecordHeaderException( Repo repo, String set, List<RecordHeader> headers, Throwable cause )
     {
         super( generateMessage( repo, set, cause ), cause );
         this.repo = repo;
         this.set = set;
+        this.headers = headers;
     }
 
     /**
@@ -77,5 +83,13 @@ public class RecordHeaderException extends Exception
     public Optional<String> getSet()
     {
         return Optional.ofNullable(set);
+    }
+
+    /**
+     * Get the list of record headers.
+     */
+    public List<RecordHeader> getHeaders()
+    {
+        return headers;
     }
 }

--- a/src/main/java/eu/cessda/oaiharvester/RepositoryClient.java
+++ b/src/main/java/eu/cessda/oaiharvester/RepositoryClient.java
@@ -127,9 +127,10 @@ class RepositoryClient
     List<RecordHeader> retrieveRecordHeaders( Repo repo, Repo.MetadataFormat metadataFormat, LocalDate fromDate ) throws RecordHeaderException
     {
         log.trace( "URL: {}, set: {}", repo.url(), metadataFormat.setSpec() );
+        final var records = new ArrayList<RecordHeader>();
+
         try
         {
-            final var records = new ArrayList<RecordHeader>();
             var li = ListIdentifiers.instance( httpClient, repo.url(), fromDate, null, metadataFormat.setSpec(), metadataFormat.metadataPrefix() );
 
             Optional<String> resumptionToken;
@@ -160,7 +161,7 @@ class RepositoryClient
         }
         catch ( IOException | SAXException | DateTimeParseException e )
         {
-            throw new RecordHeaderException( repo, metadataFormat.setSpec(), e );
+            throw new RecordHeaderException( repo, metadataFormat.setSpec(), records, e );
         }
     }
 }

--- a/src/main/java/org/oclc/oai/harvester2/verb/ListIdentifiers.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/ListIdentifiers.java
@@ -41,8 +41,6 @@ import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -161,8 +159,6 @@ public final class ListIdentifiers extends HarvesterVerb implements Resumable
 	 */
 	private static URI getRequestURL( URI baseURL, String resumptionToken )
 	{
-		return URI.create(baseURL + "?verb=ListIdentifiers"
-				+ "&resumptionToken=" + URLEncoder.encode( resumptionToken, StandardCharsets.UTF_8 )
-		);
+		return URI.create(baseURL + "?verb=ListIdentifiers&resumptionToken=" +  resumptionToken );
 	}
 }

--- a/src/test/java/org/oclc/oai/harvester2/verb/ListIdentifiersTests.java
+++ b/src/test/java/org/oclc/oai/harvester2/verb/ListIdentifiersTests.java
@@ -32,7 +32,6 @@ import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.stream.Collectors;
 
-import static java.net.URLEncoder.encode;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -140,7 +139,7 @@ class ListIdentifiersTests
         // When
         var resumptionToken = "3/6/7/ddi/null/2017-01-01/null";
         when( httpClient.getHttpResponse(
-            URI.create("http://localhost:4556/?verb=ListIdentifiers&resumptionToken=" + encode( resumptionToken, UTF_8 ) ) )
+            URI.create("http://localhost:4556/?verb=ListIdentifiers&resumptionToken=" + resumptionToken ) )
         ).thenReturn( new ByteArrayInputStream(
             GET_LIST_IDENTIFIERS_XML_RESUMPTION_TOKEN_NOT_MOCKED_FOR_INVALID.getBytes( UTF_8 )
         ));


### PR DESCRIPTION
This was caused by URLEncoding the resumption token. SND expects the token to be returned exactly as it was transmitted.

This closes cessda/cessda.cdc.versions#655.