### PR TITLE
#699: Remove support for the NESSTAR date format

### DIFF
--- a/src/main/java/org/oclc/oai/harvester2/verb/HarvesterVerb.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/HarvesterVerb.java
@@ -196,9 +196,7 @@ public abstract sealed class HarvesterVerb permits GetRecord, Identify, ListIden
             }
             else if ( "datestamp".equals( localName ) )
             {
-                // NSD returns invalid ISO dates such as 2020-09-02T15:12:07+0000.
-                // This corrects the dates before parsing by replacing +0000 with Z.
-                var datestampString = node.getTextContent().trim().replace( "+0000", "Z" );
+                var datestampString = node.getTextContent().trim();
                 datestamp = OAI_DATE_TIME_FORMATTER.parseBest( datestampString, OffsetDateTime::from, LocalDateTime::from, LocalDate::from );
             }
             else if ( "setSpec".equals( localName ) )

--- a/src/test/java/org/oclc/oai/harvester2/verb/ListIdentifiersTests.java
+++ b/src/test/java/org/oclc/oai/harvester2/verb/ListIdentifiersTests.java
@@ -29,7 +29,6 @@ import org.xml.sax.SAXException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.time.OffsetDateTime;
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -41,19 +40,6 @@ import static org.oclc.oai.harvester2.verb.RecordHeadersMock.*;
 
 class ListIdentifiersTests
 {
-    //language=XML
-    private static final String NSD_DATE_FORMAT_RESPONSE = """
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/">
-            <responseDate>2021-07-04T00:00:29.482Z</responseDate>
-            <request verb="ListIdentifiers" metadataPrefix="oai_ddi">http://129.177.90.182/</request>
-            <ListIdentifiers>
-                <header>
-                    <identifier>http://nsddata.nsd.uib.no:80/obj/fStudy/NSD2200-2</identifier>
-                    <datestamp>2020-09-02T15:12:03+0000</datestamp>
-                </header>
-            </ListIdentifiers>
-        </OAI-PMH>""";
 
     @Test
     void shouldReturnRecordHeaders() throws IOException, SAXException
@@ -150,23 +136,5 @@ class ListIdentifiersTests
         );
 
         assertEquals(resumptionToken, listIdentifiers.getResumptionToken().orElseThrow());
-    }
-
-    @Test
-    void shouldHandleNSDDateFormat() throws IOException, SAXException
-    {
-        // When
-        var listIdentifiers = new ListIdentifiers(
-            new InputSource( new ByteArrayInputStream( NSD_DATE_FORMAT_RESPONSE.getBytes( UTF_8 ) ) )
-        );
-
-        // Then
-        var identifiersIDs = listIdentifiers.getIdentifiers();
-
-        var firstIdentifer = identifiersIDs.getFirst();
-
-        // Assert the header has the expected content
-        assertEquals( "http://nsddata.nsd.uib.no:80/obj/fStudy/NSD2200-2", firstIdentifer.identifier() );
-        assertEquals( OffsetDateTime.parse( "2020-09-02T15:12:03Z" ), firstIdentifer.datestamp() );
     }
 }


### PR DESCRIPTION
This closes https://github.com/cessda/cessda.cdc.versions/issues/699.