### PR TITLE
Update application-snd.yml

### DIFF
--- a/src/main/resources/application-snd.yml
+++ b/src/main/resources/application-snd.yml
@@ -68,4 +68,4 @@ harvester:
     incremental: 0 0 */2 * * *
     full: 00 31 12 * * ?
   repos:
-  - url: https://snd.se/oai-pmh?verb=ListIdentifiers&set=subject:ssif:5
+  - url: https://api.researchdata.se/oai-pmh?verb=ListIdentifiers&set=subject:ssif:5


### PR DESCRIPTION
Change harvesting endpoint to api.researchdata.se

Same set (only datasets tagged with social science in the Swedish research subject heading vocabulary).

This endpoint will also include additional datasets hosted on some other Swedish research organizations. For source see the filter "Source Repository" on: https://researchdata.se/en/catalogue?subject=5 The DOI:s for these resources will resolve to the source landing page.
![image](https://github.com/user-attachments/assets/bff78d74-f8ff-4424-a3fa-41213a032182)

We have done some refactoring on our DDI 3.3 and DDI 2.5 exports so please do a test run and get back to me if there is anything we need to fix.

Best regards,
Olof