### PR TITLE
#734: Add the ability for the harvester to compare timestamps of the OAI-PMH headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>eu.cessda</groupId>
 	<artifactId>oaiharvester</artifactId>
-	<version>3.6.0</version>
+	<version>4.1.0</version>
 	<name>CESSDA OAI-PMH Metadata Harvester</name>
 	<description>
 		A microservice for harvesting metadata made available by third parties by using the Open Archives
@@ -72,6 +72,17 @@
 
 	<build>
 		<plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
@@ -84,13 +95,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<!-- http://stackoverflow.com/a/9825309 -->
 				<configuration>
-					<argLine>@{argLine} -Dfile.encoding=UTF-8</argLine>
-					<reuseForks>true</reuseForks>
-					<forkCount>1</forkCount>
-					<runOrder>failedfirst</runOrder>
-					<dependenciesToScan>
-						<dependency>org.gesis.commons:commons-test</dependency>
-					</dependenciesToScan>
+					<argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/eu/cessda/oaiharvester/Harvester.java
+++ b/src/main/java/eu/cessda/oaiharvester/Harvester.java
@@ -62,7 +62,7 @@ public class Harvester implements CommandLineRunner
     private final RepositoryClient repositoryClient;
 
     @Autowired
-    public Harvester( HttpClient httpClient, HarvesterConfiguration harvesterConfiguration, RepositoryClient repositoryClient )
+    Harvester( HttpClient httpClient, HarvesterConfiguration harvesterConfiguration, RepositoryClient repositoryClient )
     {
         this.httpClient = httpClient;
         this.harvesterConfiguration = harvesterConfiguration;
@@ -276,7 +276,7 @@ public class Harvester implements CommandLineRunner
      * @param complete       {@code true} if all metadata headers were retrieved.
      * @return the number of records successfully harvested.
      */
-    @SuppressWarnings( "java:S1141" )
+    @SuppressWarnings( { "java:S1141", "java:S3776", "java:S5443" } )
     private int harvestRecords( List<RecordHeader> records, Repo repo, String metadataFormat, Path repoDirectory, boolean complete )
     {
         int retrievedRecords = 0;
@@ -346,7 +346,7 @@ public class Harvester implements CommandLineRunner
                     }
                     catch ( IOException e )
                     {
-                        // ignore
+                        // ignore file deletion exceptions
                     }
                 }
             }

--- a/src/main/java/eu/cessda/oaiharvester/HttpClient.java
+++ b/src/main/java/eu/cessda/oaiharvester/HttpClient.java
@@ -46,7 +46,7 @@ public class HttpClient
     private final int retryDelay;
 
     @Autowired
-    public HttpClient( HarvesterConfiguration harvesterConfiguration )
+    HttpClient( HarvesterConfiguration harvesterConfiguration )
     {
         // TK added default timeout for dataverses taking too long to respond / stall
         this.client = Methanol.newBuilder()

--- a/src/main/java/org/oclc/oai/harvester2/verb/GetRecord.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/GetRecord.java
@@ -115,7 +115,7 @@ public final class GetRecord extends HarvesterVerb
      * <p>
      * This method checks whether the datestamps in the OAI-PMH header differ and returns {@code true} if they do.
      *
-     * @param newRecord an input stream representing the record that would be harvested
+     * @param newRecordHeader an input stream representing the record that would be harvested
      * @param oldRecord an input stream representing the already harvested record
      * @return {@code true} if the timestamps differ or if an IO error occurs loading
      */

--- a/src/main/java/org/oclc/oai/harvester2/verb/GetRecord.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/GetRecord.java
@@ -40,6 +40,7 @@ import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -107,6 +108,25 @@ public final class GetRecord extends HarvesterVerb
             + "&identifier=" + identifier
             + "&metadataPrefix=" + metadataPrefix
         );
+    }
+
+    /**
+     * Determine whether a record should be harvested.
+     * <p>
+     * This method checks whether the datestamps in the OAI-PMH header differ and returns {@code true} if they do.
+     *
+     * @param newRecord an input stream representing the record that would be harvested
+     * @param oldRecord an input stream representing the already harvested record
+     * @return {@code true} if the timestamps differ or if an IO error occurs loading
+     */
+    public static boolean shouldHarvest( RecordHeader newRecordHeader, InputStream oldRecord ) throws XMLStreamException
+    {
+        // Try opening existing file
+        var previousRecordReader = xmlInputFactory.createXMLStreamReader( oldRecord );
+        var previousDateStamp = getDateStamp( previousRecordReader );
+
+        // Harvest if the datestamp is not equal
+        return !newRecordHeader.datestamp().equals( previousDateStamp );
     }
 
     /**

--- a/src/main/java/org/oclc/oai/harvester2/verb/HarvesterVerb.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/HarvesterVerb.java
@@ -105,7 +105,7 @@ public abstract sealed class HarvesterVerb permits GetRecord, Identify, ListIden
             // Log SAX warnings as debug messages
             if (log.isDebugEnabled())
             {
-                log.debug( "{}", exception.toString() );
+                log.debug( exception.toString() );
             }
         }
 

--- a/src/main/java/org/oclc/oai/harvester2/verb/ListIdentifiers.java
+++ b/src/main/java/org/oclc/oai/harvester2/verb/ListIdentifiers.java
@@ -89,16 +89,17 @@ public final class ListIdentifiers extends HarvesterVerb implements Resumable
 	}
 
 	/**
-	 * Construct a new instance of {@link ListIdentifiers}.
-	 * @param baseURL the URL of the repository.
-	 * @param from the date to harvest from. Set to {@code null} to harvest from the beginning.
-	 * @param until to date to harvest to. Set to {@code null} for no limit.
-	 * @param set the set to harvest.
-	 * @param metadataPrefix the metadata prefix to use.
-	 * @throws IOException if an IO error occurs.
-	 * @throws SAXException if an error occurs when parsing the XML.
-	 */
-	public static ListIdentifiers instance( HttpClient httpClient, URI baseURL, LocalDate from, LocalDate until, String set, String metadataPrefix )
+     * Construct a new instance of {@link ListIdentifiers}.
+     *
+     * @param baseURL        the URL of the repository.
+     * @param metadataPrefix the metadata prefix to use.
+     * @param set            the set to harvest.
+     * @param from           the date to harvest from. Set to {@code null} to harvest from the beginning.
+     * @param until          to date to harvest to. Set to {@code null} for no limit.
+     * @throws IOException   if an IO error occurs.
+     * @throws SAXException  if an error occurs when parsing the XML.
+     */
+	public static ListIdentifiers instance( HttpClient httpClient, URI baseURL, String metadataPrefix, String set, LocalDate from, LocalDate until )
 			throws IOException, SAXException
 	{
 		var requestURL = getRequestURL( baseURL, from, until, set, metadataPrefix );
@@ -118,9 +119,14 @@ public final class ListIdentifiers extends HarvesterVerb implements Resumable
 	 */
 	private static URI getRequestURL( URI baseURL, LocalDate from, LocalDate until, String set, String metadataPrefix )
 	{
+        // Validate required parameters
+        Objects.requireNonNull( baseURL, "baseURL must not be null" );
+        Objects.requireNonNull( metadataPrefix, "metadataPrefix must not be null" );
 
+        // Construct the request URL
 		StringBuilder requestURL = new StringBuilder( baseURL.toString() );
 		requestURL.append( "?verb=ListIdentifiers" );
+        requestURL.append( "&metadataPrefix=" ).append( metadataPrefix );
 		if ( from != null )
 		{
 			requestURL.append( "&from=" ).append( from );
@@ -133,7 +139,6 @@ public final class ListIdentifiers extends HarvesterVerb implements Resumable
 		{
 			requestURL.append( "&set=" ).append( set );
 		}
-		requestURL.append( "&metadataPrefix=" ).append( metadataPrefix );
 		return URI.create(requestURL.toString());
 	}
 


### PR DESCRIPTION
Comparing OAI-PMH headers allows the harvester to skip downloading records that are unchanged.

This commit also skips cleaning up records if the process of retrieving identifiers from a repository is incomplete.